### PR TITLE
Implement Profile schema

### DIFF
--- a/models/Profile.js
+++ b/models/Profile.js
@@ -1,0 +1,112 @@
+const mongoose = require('mongoose');
+const ProfileSchema = new mongoose.Schema({
+    user: {
+        type: mongoose.Schema.Types.ObjectId,
+        ref: 'users'
+    },
+    company: {
+        type: String
+    },
+    website: {
+        type: String
+    },
+    location: {
+        type: String
+    },
+    status: {
+        type: String,
+        required: true
+    },
+    skills: {
+        type: [String],
+        required: true
+    },
+    bio: {
+        type: String
+    },
+    githubusername: {
+        type: String
+    },
+    experience: [
+        {
+            title: {
+                type: String,
+                required: true
+            },
+            company: {
+                type: String,
+                required: true
+            },
+            location: {
+                type: String
+            },
+            from: {
+                type: Date,
+                required: true
+            },
+            to: {
+                type: Date
+            },
+            current: {
+                type: Boolean,
+                default: false
+            },
+            description: {
+                type: String
+            }
+        }
+    ],
+    education: [
+        {
+            school: {
+                type: String,
+                required: true
+            },
+            degree: {
+                type: String,
+                required: true
+            },
+            fieldofstudy: {
+                type: String,
+                required: true
+            },
+            from: {
+                type: Date,
+                required: true
+            },
+            to: {
+                type: Date
+            },
+            current: {
+                type: Boolean,
+                default: false
+            },
+            description: {
+                type: String
+            }
+        }
+    ],
+    social: {
+        youtube: {
+            type: String
+        },
+        twitter: {
+            type: String
+        },
+        facebook: {
+            type: String
+        },
+        linkedin: {
+            type: String
+        },
+        instagram: {
+            type: String
+        }
+    },
+    date: {
+        type: Date,
+        default: Date.now
+    }
+});
+
+module.exports = mongoose.model('profile', ProfileSchema);


### PR DESCRIPTION
This pull request introduces a new Mongoose schema for user profiles. The schema is designed to store detailed information about a user's professional and educational background, as well as social media links.

New profile schema for user data:

* Added `ProfileSchema` in `models/Profile.js` to store user-related information such as company, website, location, status, skills, bio, and GitHub username.
* Included nested arrays for `experience` and `education`, each with relevant fields (e.g., title, company, school, degree, dates, and descriptions).
* Added a `social` object to capture various social media links (YouTube, Twitter, Facebook, LinkedIn, Instagram).
* Set up default values for certain fields, such as `date` and `current` status in experience and education entries.