### PR TITLE
Implement get all profiles and get a specific profile by Id

### DIFF
--- a/config/routes/api/profile.js
+++ b/config/routes/api/profile.js
@@ -79,5 +79,40 @@ router.post('/', [auth, [
     }
 }); 
 
+// @route  GET api/profile
+// @desc   Get all profiles
+// @access Public
+router.get('/', async (req, res) => {
+    try {
+        const profiles = await Profile.find().populate('user', ['name', 'avatar']);
+        return res.json(profiles);
+    } catch (err) {
+        console.error(err.message);
+        res.status(500).send('Server error');
+    }
+})
+
+// @route  GET api/profile/user/:user_id
+// @desc   Get profile by user ID
+// @access Public
+router.get('/user/:user_id', async (req, res) => {
+    try {
+        const profile = await Profile.findOne({ user: req.params.user_id }).populate('user', ['name', 'avatar']);
+        
+        if (!profile) return res.status(400).json({ msg: 'Profile not found' });
+        return res.json(profile);
+    } catch (err) {
+        console.error(err.message);
+        if (err.kind == 'ObjectId') {
+            return res.status(400).json({ msg: 'Profile not found' });
+        }
+        res.status(500).send('Server error');
+    }
+})
+
+
+
+
+
 
 module.exports = router;

--- a/models/Profile.js
+++ b/models/Profile.js
@@ -2,7 +2,7 @@ const mongoose = require('mongoose');
 const ProfileSchema = new mongoose.Schema({
     user: {
         type: mongoose.Schema.Types.ObjectId,
-        ref: 'users'
+        ref: 'user'
     },
     company: {
         type: String


### PR DESCRIPTION
This pull request adds new API endpoints for retrieving user profiles and corrects a reference in the `Profile` model schema. The main changes are the addition of two public routes to fetch all profiles or a specific profile by user ID, and a fix to the `Profile` schema to ensure the correct model is referenced.

**API Enhancements:**

* Added a `GET /api/profile` route to retrieve all profiles, including associated user names and avatars.
* Added a `GET /api/profile/user/:user_id` route to retrieve a specific user's profile by their user ID, with error handling for missing profiles or invalid IDs.

**Model Correction:**

* Updated the `Profile` schema's `user` field to reference the correct `user` model instead of `users`.