### PR TITLE
Add Delete profile and user endpoint

### DIFF
--- a/config/routes/api/profile.js
+++ b/config/routes/api/profile.js
@@ -110,9 +110,20 @@ router.get('/user/:user_id', async (req, res) => {
     }
 })
 
+// @route  DELETE api/profile
+// @desc   Delete profile, user & posts
+// @access Private
+router.delete('/', auth, async (req, res) => {
+    try {
+        await Profile.findOneAndDelete({ user: req.user.id });
+        await User.findOneAndDelete({ _id: req.user.id });
 
-
-
+        res.json({ msg: 'User deleted' });
+    } catch (err) {
+        console.error(err.message);
+        res.status(500).send('Server error');   
+    }
+})
 
 
 module.exports = router;


### PR DESCRIPTION
This pull request adds a new endpoint to allow authenticated users to delete their profile, user account, and associated posts. The most important change is the addition of a `DELETE` route for user and profile deletion.

User and profile deletion:

* Added a new `DELETE /api/profile` route in `config/routes/api/profile.js` that allows authenticated users to delete their profile and user account, returning a confirmation message upon success.