### PR TITLE
Feat/update experience

### DIFF
--- a/config/routes/api/profile.js
+++ b/config/routes/api/profile.js
@@ -161,4 +161,28 @@ router.put('/experience', [auth, [
     }
 });     
 
+// @route  DELETE api/profile/experience/:exp_id
+// @desc   Delete profile experience
+// @access Private
+
+router.delete('/experience/:exp_id', auth, async (req, res) => {
+    try {
+        const profile = await Profile.findOne({ user: req.user.id });
+
+        // Get remove index
+        const removeIndex = profile.experience.map(item => item.id).indexOf(req.params.exp_id);
+
+        if (removeIndex === -1) {
+            return res.status(400).json({ msg: 'Experience not found' });
+        }
+
+        profile.experience.splice(removeIndex, 1);
+        await profile.save();
+        res.json(profile);
+    } catch (err) {
+        console.error(err.message);
+        res.status(500).send('Server error');
+    }
+});
+
 module.exports = router;


### PR DESCRIPTION
This pull request adds new functionality to the profile API, specifically for managing a user's experience entries. The most important changes are the addition of endpoints to add and delete experience items from a user's profile.

**Experience management endpoints:**

* Added a `PUT /api/profile/experience` endpoint to allow authenticated users to add new experience entries to their profile, including validation for required fields (`title`, `company`, `from`).
* Added a `DELETE /api/profile/experience/:exp_id` endpoint to allow authenticated users to remove an experience entry from their profile by its ID, with error handling for missing entries.