### PR TITLE
feat: get github repos

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,4 @@
 MONGODB_URI=your_mongodb_connection_string_here
 JWT_SECRET=your_jwt_secret_here
+GITHUB_CLIENT_ID=your_github_client_id_here
+GITHUB_CLIENT_SECRET=your_github_client_secret_here

--- a/config/routes/api/profile.js
+++ b/config/routes/api/profile.js
@@ -185,4 +185,25 @@ router.delete('/experience/:exp_id', auth, async (req, res) => {
     }
 });
 
+// @route  GET api/profile/github/:username
+// @desc   Get user repos from GitHub
+// @access Public
+router.get('/github/:username', async (req, res) => {
+    try {
+        const uri = encodeURI(`https://api.github.com/users/${req.params.username}/repos?per_page=5&sort=created:asc&client_id=${process.env.GITHUB_CLIENT_ID}&client_secret=${process.env.GITHUB_CLIENT_SECRET}`);
+        const headers = {
+            'user-agent': 'node.js'
+        };
+
+        const gitHubResponse = await fetch(uri, { headers });
+        if (gitHubResponse.status !== 200) {
+            return res.status(404).json({ msg: 'No GitHub profile found' });
+        }
+        const data = await gitHubResponse.json();
+        return res.json(data);
+    } catch (err) {
+        console.error(err.message);
+        res.status(500).send('Server error');
+    }
+});
 module.exports = router;


### PR DESCRIPTION
This pull request adds integration with the GitHub API to fetch user repositories and updates environment configuration to support this feature. The main changes are grouped below.

**GitHub API Integration:**

* Added a new GET endpoint in `config/routes/api/profile.js` (`/api/profile/github/:username`) that fetches the specified user's public repositories from GitHub, returning the five most recently created repositories. This endpoint uses the GitHub API and requires the client ID and secret from environment variables.

**Environment Configuration:**

* Updated `.env.example` to include `GITHUB_CLIENT_ID` and `GITHUB_CLIENT_SECRET` variables, which are necessary for authenticating requests to the GitHub API.