### PR TITLE
feat: Add endpoint to create, delete and get post

### DIFF
--- a/config/routes/api/posts.js
+++ b/config/routes/api/posts.js
@@ -34,4 +34,60 @@ router.post('/', [auth, [
     }
 });
 
+// @route  GET api/posts
+// @desc   Get all posts
+// @access Private
+router.get('/', auth, async (req, res) => {
+    try {
+        const posts = await Post.find().sort({ date: -1 });
+        res.json(posts);
+    } catch (err) {
+        console.error(err.message);
+        res.status(500).send('Server Error');
+    }
+});
+
+// @route  GET api/posts/:id
+// @desc   Get post by ID
+// @access Private
+router.get('/:id', auth, async (req, res) => {
+    try {
+        const posts = await Post.findById(req.params.id );
+        if (!posts) {
+            return res.status(404).json({ msg: 'Post not found' });
+        }
+        res.json(posts);
+    } catch (err) {
+        if (err.kind === 'ObjectId') {
+            return res.status(404).json({ msg: 'Post not found' });
+        }
+        console.error(err.message);
+        res.status(500).send('Server Error');
+    }
+});
+
+// @route  DELETE api/posts/:id
+// @desc   DELETE post by ID
+// @access Private
+router.delete('/:id', auth, async (req, res) => {
+    try {
+        const posts = await Post.findById(req.params.id );
+        if (posts.user.toString() !== req.user.id) {
+            return res.status(401).json({ msg: 'User not authorized' });
+        }
+
+        if (!posts) {
+            return res.status(404).json({ msg: 'Post not found' });
+        }
+        await posts.deleteOne();
+        res.json({ msg: 'Post removed' });
+    } catch (err) {
+        if (err.kind === 'ObjectId') {
+            return res.status(404).json({ msg: 'Post not found' });
+        }
+        console.error(err.message);
+        res.status(500).send('Server Error');
+    }
+});
+
 module.exports = router;


### PR DESCRIPTION
This pull request adds new API endpoints to the `config/routes/api/posts.js` file, expanding the functionality for managing posts. The main changes include adding routes to get all posts, get a post by ID, and delete a post by ID, all requiring authentication.

**New API endpoints for post management:**

* Added a `GET /api/posts` endpoint to retrieve all posts, sorted by date in descending order.
* Added a `GET /api/posts/:id` endpoint to retrieve a single post by its ID, with proper error handling for not found cases.
* Added a `DELETE /api/posts/:id` endpoint to allow users to delete their own posts by ID, including authorization and error handling.