### PR TITLE
feat: Implement like and dislike of a specific post

### DIFF
--- a/config/routes/api/posts.js
+++ b/config/routes/api/posts.js
@@ -90,4 +90,75 @@ router.delete('/:id', auth, async (req, res) => {
     }
 });
 
+// @route  PUT api/posts/like/:id
+// @desc   Like a post
+// @access Private
+router.put('/like/:id', auth, async (req, res) => {
+    try {
+        const post = await Post.findById(req.params.id );
+
+        // Check if the post has already been liked by this user
+        if (post.likes.some(like => like.user.toString() === req.user.id)) {
+            return res.status(400).json({ msg: 'Post already liked' });
+        }
+
+        post.likes.unshift({ user: req.user.id });
+        await post.save();
+        res.json(post.likes);
+    } catch (err) {
+        if (err.kind === 'ObjectId') {
+            return res.status(404).json({ msg: 'Post not found' });
+        }
+        console.error(err.message);
+        res.status(500).send('Server Error');
+    }
+});
+
+// @route  PUT api/posts/unlike/:id
+// @desc   Unlike a post
+// @access Private
+router.put('/unlike/:id', auth, async (req, res) => {
+    try {
+        const post = await Post.findById(req.params.id );
+
+        // Check if the post has not yet been liked by this user
+        if (!post.likes.some(like => like.user.toString() === req.user.id)) {
+            return res.status(400).json({ msg: 'Post has not yet been liked' });
+        }
+
+        // Remove the like
+        post.likes = post.likes.filter(({ user }) => user.toString() !== req.user.id);
+        await post.save();
+        res.json(post.likes);
+    } catch (err) {
+        console.error(err.message);
+        res.status(500).send('Server Error');
+    }
+});
+
+// @route  PUT api/posts/unlike/:id
+// @desc   Unlike a post
+// @access Private
+router.post('/unlike/:id', auth, async (req, res) => {
+    try {
+        const post = await Post.findById(req.params.id );
+
+        if (post.likes.some(like => like.user.toString() === req.user.id)) {
+            return res.status(400).json({ msg: 'Post has not yet been liked' });
+        }
+        const removeIndex = post.likes
+            .map(like => like.user.toString())
+            .indexOf(req.user.id);
+            
+        post.likes.splice(removeIndex, 1);
+        await post.save();
+        res.json(post.likes);
+    } catch (err) {
+        if (err.kind === 'ObjectId') {
+            return res.status(404).json({ msg: 'Post not found' });
+        }
+        console.error(err.message);
+        res.status(500).send('Server Error');
+    }
+});
 module.exports = router;


### PR DESCRIPTION
This pull request adds new endpoints for liking and unliking posts in the `api/posts` route, allowing authenticated users to like or unlike a post. The main changes introduce both PUT and POST handlers for these actions, including error handling for duplicate likes and unlikes.

**New like/unlike endpoints:**

* Added a PUT endpoint at `api/posts/like/:id` that allows an authenticated user to like a post, with checks to prevent duplicate likes. (`config/routes/api/posts.js`, [config/routes/api/posts.jsR93-R163](diffhunk://#diff-aac11905cf35efa6c9da684a87ea0d0464cad6a86bb0daaff5103b94dfbf7fb6R93-R163))
* Added a PUT endpoint at `api/posts/unlike/:id` to allow an authenticated user to unlike a post, ensuring the user has previously liked the post before unliking. (`config/routes/api/posts.js`, [config/routes/api/posts.jsR93-R163](diffhunk://#diff-aac11905cf35efa6c9da684a87ea0d0464cad6a86bb0daaff5103b94dfbf7fb6R93-R163))
* Added a POST endpoint at `api/posts/unlike/:id` (note: this appears redundant and may be an accidental duplicate) that attempts to unlike a post, but contains logic that may not function as intended (it checks if the user has liked the post and returns an error if so, which is the opposite of expected behavior). (`config/routes/api/posts.js`, [config/routes/api/posts.jsR93-R163](diffhunk://#diff-aac11905cf35efa6c9da684a87ea0d0464cad6a86bb0daaff5103b94dfbf7fb6R93-R163))