### PR TITLE
feat: Implement endpoint to add and delete comments

### DIFF
--- a/config/routes/api/posts.js
+++ b/config/routes/api/posts.js
@@ -90,4 +90,60 @@ router.delete('/:id', auth, async (req, res) => {
     }
 });
 
+// @route  POST api/posts/comment/:id
+// @desc   Comment on a post
+// @access Private
+router.post('/comment/:id', [auth, [
+    check('text', 'Text is required').not().isEmpty()
+]], async (req, res) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+        return res.status(400).json({ errors: errors.array() });
+    }
+    try {
+        const user = await User.findById(req.user.id).select('-password');
+        const post = await Post.findById(req.params.id);    
+
+        const newComment = {
+            text: req.body.text,
+            name: user.name,
+            avatar: user.avatar,
+            user: req.user.id
+        };
+
+        post.comments.unshift(newComment);
+        await post.save();
+        res.json(post.comments);
+    } catch (err) {
+        console.error(err.message);
+        res.status(500).send('Server Error');
+    }   
+});
+
+// @route  DELETE api/posts/comment/:id/:comment_id
+// @desc   Delete comment on a post
+// @access Private
+router.delete('/comment/:id/:comment_id', auth, async (req, res) => {
+    try {
+        const post = await Post.findById(req.params.id);    
+
+        const comment = post.comments.find(comment => comment.id === req.params.comment_id);
+        if (!comment) {
+            return res.status(404).json({ msg: 'Comment does not exist' });
+        }
+        if (comment.user.toString() !== req.user.id) {
+            return res.status(401).json({ msg: 'User not authorized' });
+        }
+
+        const removeIndex = post.comments.map(comment => comment.id).indexOf(req.params.comment_id);
+        post.comments.splice(removeIndex, 1);
+        await post.save();
+        res.json(post.comments);
+    } catch (err) {
+        console.error(err.message);
+        res.status(500).send('Server Error');
+    }   
+});
+
+
 module.exports = router;


### PR DESCRIPTION
This pull request adds functionality for users to comment on posts and delete their own comments. The main changes are the introduction of two new routes in the `api/posts.js` router for handling comments.

**New comment features:**

* Added a POST route at `/api/posts/comment/:id` to allow authenticated users to add comments to a post. The route validates that comment text is provided, attaches user details to the comment, and returns the updated list of comments.
* Added a DELETE route at `/api/posts/comment/:id/:comment_id` to allow users to delete their own comments from a post. The route checks for comment existence and ownership before removal, ensuring only the comment's author can delete it.